### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - Fork (typically created using the GitHub web interface only): 
 
-- Local Clone (typically created using the Git CLI with 'git clone` only): 
+- Local Clone (typically created using the Git CLI with `git clone` only): 
 
 - Branch (created using the GitHub web interface, or using the Git CLI with `git branch` or `git checkout`): 
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 
 ##### Managing Code Edits:
 
-- Stage Changes (typically created using the Git CLI with 'git add` only):
+- Stage Changes (typically created using the Git CLI with `git add` only):
 
 - Commit Changes (created using the GitHub web interface, or using the Git CLI with `git commit`): 
 
-- Publish Changes to Remote Clone (typically created using the Git CLI with 'git push` only): 
+- Publish Changes to Remote Clone (typically created using the Git CLI with `git push` only): 
 
 - Pull Request or PR (typically created using the GitHub web interface only): 
 


### PR DESCRIPTION
Replaced ' with ` in cases where markdown code formatting tags were mistyped.